### PR TITLE
Synchronize score reads to line changes

### DIFF
--- a/player.py
+++ b/player.py
@@ -135,25 +135,50 @@ class Player:
 
             return True
 
+        # When digits change in an interlaced setup, the transition frame can be blurry and yield an incorrect read
+        # We introduce a 1-frame delay system for the value to stabilize before checking the value
+
+        # This means stats derived from the value will appear with one frame delay, which we consider acceptable for human viewing
+
+        # In some (rare) cases, the transition to the next value is still read as the old value, and thus not considered a change,
+        # Such cases introduce 2 problems:
+        # 1) by the time the change is detected, the 1-frame delay kicks in, and so the value would be changed with a cumulated 2 frames delay
+        # 2) if score is detected as change, but not lines, changes that should be synchronized (lines and score) would be detected as individual
+        # changes in 2 consecutive frames, causing stats to jump around.
+
+        # The double jump in stats is worse than the delay, so if a line change is detected while there was already a pendnig score read
+        # we assume the line is already ready to be read and we read it right away.
+
+        # That is done with that weird while loop, so we have 2 chances as evaluating self.pending_lines *cough*
+
         changed = False
 
-        if self.pending_lines:
-            changed = True
-            self.pending_lines = False
+        while True:
+            if self.pending_lines:
+                changed = True
+                self.pending_lines = False
 
-            if lines is None or lines == 0:
-                self.tetris_line_count = 0
-            else:
-                cleared = lines - (self.lines or 0)
-                if cleared == 4:
-                    self.tetris_line_count += 4
+                if lines is None or lines == 0:
+                    self.tetris_line_count = 0
+                else:
+                    cleared = lines - (self.lines or 0)
+                    if cleared == 4:
+                        self.tetris_line_count += 4
 
-            self.lines = lines
-            self.level = self.level_fixer.fix(level_label, level)[1]
-            self.pace_score = self.getPaceMaxScore()
+                self.lines = lines
+                self.level = self.level_fixer.fix(level_label, level)[1]
+                self.pace_score = self.getPaceMaxScore()
+                self.pending_score = True  # lines, have changed, force a score read
 
-        elif lines != self.lines:
-            self.pending_lines = True
+            elif lines != self.lines:
+                self.pending_lines = True
+                if self.pending_score:
+                    # because score was already pending, the line value is (probably) already
+                    # clean to read but we somehow didn't detect the change previously
+                    # let's read it right away after all!
+                    continue
+
+            break
 
         if self.pending_score:
             self.pending_score = False


### PR DESCRIPTION
## Background

1. So the tool so far reads values with one frame delay. It does that because when values change, the transition frame is blurry and can cause an incorrect read.
2. Values are stable: score/lines/level cannot changed over consecutive frames (need line clear, or pieces to fall down , etc), so when a change is detected, the script marks a read as pending and reads it at the next frame. That means stats are actually computed one frame behind, compared to the value change, but in the final video, that's not perceptible when watching in real time.
3. A line change is always accompanied by a score change, but a score change may happen independently (push down points!), so the script applies delay reads independently on score and lines (level can only change with lines, so level reads are bundled with line reads)

Now... In the sample files @aGameScout#3745 sent me, there was one frame, where lines and scores where transitioning after a clear BUT the blurriness on lines was read as the previous value, so it was not detected as a change :expressionless: That made score be detected first, and and then line detected one frame later. That caused the pace to jump twice in 2 frames, which is not nice.

![image](https://user-images.githubusercontent.com/935223/111060653-6e67d400-84d9-11eb-89d5-e91cd2feda4f.png)


## Approach
1. All detected line changes should read score right away, even if a score change was not detected
2. If a line change is detected, kicking off its own 1-frame delay, and the 1-frame delay of score was ongoing, the score read is delayed by one more frame

Item 2) above means that when score change was detected before line change, the actual overall read will be delayed by 2 frames. That will make the change occur 2 frames after they happened, but it should ensure they are synchronized. It's not ideal, but I reckon this will still be good enough for human viewing 🤞 

## Notes
* This whole thing assumes the values have stabilized in one frame, so far the tool makes that assumption anyway (i.e. `pending_lines` and `pending_score` are boolean, they're not multi-frame counters
* In Tetris Rate Adder. I did create a local frame buffer, where the values were backfilled into the skipped transition frames. The same could eventually be done here.


